### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix a typo

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git*,*.pdf,.codespellrc
+check-hidden = true
+# ignore-regex = 
+# ignore-words-list =

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/docs/projects/qa.md
+++ b/docs/projects/qa.md
@@ -1,4 +1,4 @@
-# Quality Assesment (QA)
+# Quality Assessment (QA)
 
 While traditionally regarded as noise, systemic physiological processes are frequently shown to be linked with cognitive processes and may contribute valuable information to fMRI studies. Recognizing this, neuroimaging research increasingly draws upon concurrent recordings of peripheral physiology to enhance fMRI analysis. However, the usefulness of physiological data is contingent upon the quality of the recordings as well as expertise in data handling. Not only is quality assessment a tedious process, but the assessments can also vary significantly between raters. While there are manual and template-based tools for assessing peak detection quality (physiopy’s peakdet, PhysIO, etc.), and automated exclusion criteria based on statistical summary metrics, we are not aware of automated approaches that can provide a rapid, effective determination of quality on the whole-scan or windowed level.
 


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.